### PR TITLE
Updated Geth Version + system requirements

### DIFF
--- a/docs/althea/althea-testnet-docs/setting-up-a-validator-manual.md
+++ b/docs/althea/althea-testnet-docs/setting-up-a-validator-manual.md
@@ -2,7 +2,7 @@
 
 ## What do I need?
 
-A Linux server with any modern Linux distribution, 4cores, 8gb of ram and at least 20gb of SSD storage.
+A Linux server with any modern Linux distribution, 16cores, 16gb of ram and at least 320gb of SSD storage.
 
 Althea chain can be run on Windows and Mac. Binaries are provided on the releases page. But validator instructions are not provided.
 
@@ -231,9 +231,9 @@ _Please only run one or the other of the below instructions, both will not work_
 
 ```
 
-wget https://gethstore.blob.core.windows.net/builds/geth-linux-amd64-1.10.6-576681f2.tar.gz
-tar -xvf geth-linux-amd64-1.10.6-576681f2.tar.gz
-cd geth-linux-amd64-1.10.6-576681f2
+wget https://gethstore.blob.core.windows.net/builds/geth-linux-amd64-1.10.8-26675454.tar.gz
+tar -xvf geth-linux-amd64-1.10.8-26675454.tar.gz
+cd geth-linux-amd64-1.10.8-26675454
 wget https://github.com/althea-net/althea-chain/raw/main/docs/althea/configs/geth-light-config.toml
 ./geth --syncmode "light" --goerli --http --config geth-light-config.toml
 
@@ -243,9 +243,9 @@ wget https://github.com/althea-net/althea-chain/raw/main/docs/althea/configs/get
 
 ```
 
-wget https://gethstore.blob.core.windows.net/builds/geth-linux-amd64-1.10.6-576681f2.tar.gz
-tar -xvf geth-linux-amd64-1.10.6-576681f2.tar.gz
-cd geth-linux-amd64-1.10.6-576681f2
+wget https://gethstore.blob.core.windows.net/builds/geth-linux-amd64-1.10.8-26675454.tar.gz
+tar -xvf geth-linux-amd64-1.10.8-26675454.tar.gz
+cd geth-linux-amd64-1.10.8-26675454
 wget https://github.com/althea-net/althea-chain/raw/main/docs/althea/configs/geth-full-config.toml
 ./geth --goerli --http --config geth-full-config.toml
 

--- a/docs/althea/althea-testnet-docs/setting-up-a-validator-manual.md
+++ b/docs/althea/althea-testnet-docs/setting-up-a-validator-manual.md
@@ -132,7 +132,7 @@ althea tx staking create-validator \
  --amount=50000000000ualtg \
  --pubkey=$(althea tendermint show-validator) \
  --moniker="put your validator name here" \
- --chain-id=althea-testnet2v2 \
+ --chain-id=althea-testnet2v3 \
  --commission-rate="0.10" \
  --commission-max-rate="0.20" \
  --commission-max-change-rate="0.01" \
@@ -204,7 +204,7 @@ althea keys show myvalidatorkeyname
 
 ```
 
-althea tx bank send myvalidatorkeyname <your delegate cosmos address> 25000000000ufootoken --chain-id=althea-testnet2v2
+althea tx bank send myvalidatorkeyname <your delegate cosmos address> 25000000000ufootoken --chain-id=althea-testnet2v3
 
 ```
 


### PR DESCRIPTION
Updated system requirements to 320GB SSD, 6 cores, 16GB. My validator is running with those specs and running at 67%+

Updated the Geth version under lite/full node instructions.